### PR TITLE
Add `#destroy_all!` method to `ActiveRecord::Relation`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `#destroy_all!` method to `ActiveRecord::Relation`
+
+    *Shodai Suzuki*
+
 *   Allow attributes to be fetched from Arel node groupings.
 
     *Jeff Emminger*, *Gannon McGibbon*

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,
-      :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
+      :destroy_all, :destroy_all!, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -547,6 +547,29 @@ module ActiveRecord
       records.each(&:destroy).tap { reset }
     end
 
+    # Destroys the records by instantiating each
+    # record and calling its {#destroy!}[rdoc-ref:Persistence#destroy!] method.
+    # Each object's callbacks are executed (including <tt>:dependent</tt> association options).
+    # Returns the collection of objects that were destroyed; each will be frozen, to
+    # reflect that no changes should be made (since they can't be persisted).
+    # If the <tt>before_destroy</tt> callback throws +:abort+ the action is cancelled
+    # and #destroy_all! raises ActiveRecord::RecordNotDestroyed.
+    # See ActiveRecord::Callbacks for further details.
+    #
+    # Note: Instantiation, callback execution, and deletion of each
+    # record can be time consuming when you're removing many records at
+    # once. It generates at least one SQL +DELETE+ query per record (or
+    # possibly more, to enforce your callbacks). If you want to delete many
+    # rows quickly, without concern for their associations or callbacks, use
+    # #delete_all instead.
+    #
+    # ==== Examples
+    #
+    #   Person.where(age: 0..18).destroy_all!
+    def destroy_all!
+      records.each(&:destroy!).tap { reset }
+    end
+
     # Deletes the records without instantiating the records
     # first, and hence not calling the {#destroy}[rdoc-ref:Persistence#destroy]
     # method nor invoking callbacks.

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -56,7 +56,7 @@ module ActiveRecord
         :first_or_create, :first_or_create!, :first_or_initialize,
         :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
         :create_or_find_by, :create_or_find_by!,
-        :destroy_all, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by
+        :destroy_all, :destroy_all!, :delete_all, :update_all, :touch_all, :delete_by, :destroy_by
       ]
 
     def test_delegate_querying_methods

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -6,6 +6,12 @@ require "models/post"
 require "models/pet"
 require "models/toy"
 
+class CallbackCancellationAuthor < ActiveRecord::Base
+  self.table_name = "authors"
+
+  before_destroy { throw :abort }
+end
+
 class DeleteAllTest < ActiveRecord::TestCase
   fixtures :authors, :author_addresses, :posts, :pets, :toys
 
@@ -24,6 +30,36 @@ class DeleteAllTest < ActiveRecord::TestCase
 
     assert_equal [], davids.to_a
     assert_predicate davids, :loaded?
+  end
+
+  def test_destroy_all!
+    davids = Author.where(name: "David")
+
+    # Force load
+    assert_equal [authors(:david)], davids.to_a
+    assert_predicate davids, :loaded?
+
+    assert_difference("Author.count", -1) do
+      destroyed = davids.destroy_all!
+      assert_equal [authors(:david)], destroyed
+      assert_predicate destroyed.first, :frozen?
+    end
+
+    assert_equal [], davids.to_a
+    assert_predicate davids, :loaded?
+  end
+
+  def test_error_destroy_all!
+    davids = CallbackCancellationAuthor.where(name: "David")
+
+    # Force load
+    assert_equal 1, davids.to_a.size
+    assert davids.loaded?
+
+    assert_raise(ActiveRecord::RecordNotDestroyed) { davids.destroy_all! }
+
+    assert_equal 1, davids.to_a.size
+    assert davids.loaded?
   end
 
   def test_delete_all


### PR DESCRIPTION
### Summary
There is already `destroy_all`, but there are cases where you want to raise an exception if it fails. It is useful to have `destroy_all!`.
If the `before_destroy` callback throws abort the action is cancelled and `destroy_all!` raises `ActiveRecord::RecordNotDestroyed`.

### Other Information
There was a previous PR(https://github.com/rails/rails/pull/13169), but it was closed.
At that time, it was closed because it was dealt with by committing https://github.com/rails/rails/commit/5aab0c053832ded70a3a4b58cb97f8f8bba796ba, but it seems that it was actually misunderstood.
https://github.com/rails/rails/commit/5aab0c053832ded70a3a4b58cb97f8f8bba796ba changed the behaviour of CollectionAssociation#destroy_all, not Relation#destroy_all.
So I rewrote the code and created a PR.
